### PR TITLE
feat[auth]: add login with google

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "libsql-studio",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "libsql-studio",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "dependencies": {
         "@codemirror/lang-sql": "^6.5.5",
         "@lezer/common": "^1.2.1",

--- a/src/app/login/google/callback/route.ts
+++ b/src/app/login/google/callback/route.ts
@@ -1,0 +1,80 @@
+import { PROVIDER, google } from "@/lib/auth";
+import { cookies } from "next/headers";
+import { OAuth2RequestError } from "arctic";
+import * as AuthController from "@/controllers/auth";
+
+export async function GET(request: Request): Promise<Response> {
+  const url = new URL(request.url);
+  const code = url.searchParams.get("code");
+  const state = url.searchParams.get("state");
+
+  const storedState = cookies().get("google_oauth_state")?.value ?? null;
+  const storedCodeVerifier =
+    cookies().get("google_oauth_code_verifier")?.value ?? null;
+  if (
+    !code ||
+    !state ||
+    !storedState ||
+    !storedCodeVerifier ||
+    state !== storedState
+  ) {
+    return new Response(null, {
+      status: 400,
+    });
+  }
+
+  try {
+    const token = await google.validateAuthorizationCode(
+      code,
+      storedCodeVerifier
+    );
+
+    const resp = await fetch(
+      "https://openidconnect.googleapis.com/v1/userinfo",
+      {
+        headers: {
+          Authorization: `Bearer ${token.accessToken}`,
+        },
+      }
+    );
+    const googleUser: GoogleUser = await resp.json();
+
+    await AuthController.save(
+      {
+        id: googleUser.sub,
+        name: googleUser.name,
+        email: googleUser.email,
+      },
+      PROVIDER.GOOGLE
+    );
+
+    return new Response(null, {
+      status: 302,
+      headers: {
+        Location: "/",
+      },
+    });
+  } catch (e) {
+    console.error(e);
+    // the specific error message depends on the provider
+    if (e instanceof OAuth2RequestError) {
+      // invalid code
+      return new Response(null, {
+        status: 400,
+      });
+    }
+    return new Response(null, {
+      status: 500,
+    });
+  }
+}
+
+interface GoogleUser {
+  sub: string;
+  name: string;
+  given_name: string;
+  picture: string;
+  email: string;
+  email_verified: boolean;
+  locale: string;
+}

--- a/src/app/login/google/route.ts
+++ b/src/app/login/google/route.ts
@@ -1,0 +1,29 @@
+import { google } from "@/lib/auth";
+import { generateCodeVerifier, generateState } from "arctic";
+import { cookies } from "next/headers";
+
+export async function GET(): Promise<Response> {
+  const state = generateState();
+  const codeVerifier = generateCodeVerifier();
+  const url = await google.createAuthorizationURL(state, codeVerifier, {
+    scopes: ["profile", "email"],
+  });
+
+  cookies().set("google_oauth_state", state, {
+    path: "/",
+    secure: process.env.NODE_ENV === "production",
+    httpOnly: true,
+    maxAge: 60 * 10,
+    sameSite: "lax",
+  });
+
+  cookies().set("google_oauth_code_verifier", codeVerifier, {
+    path: "/",
+    secure: process.env.NODE_ENV === "production",
+    httpOnly: true,
+    maxAge: 60 * 10,
+    sameSite: "lax",
+  });
+
+  return Response.redirect(url);
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -11,12 +11,12 @@ export default function LoginPage() {
             <h2 className="text-xl font-bold">Sign In</h2>
           </CardHeader>
           <CardContent className="grid gap-4">
-            <Link href="/login/github">
-              <Button>Continue with Github</Button>
-            </Link>
-            <Link href="/login/google">
-              <Button>Continue with Google</Button>
-            </Link>
+            <Button asChild>
+              <Link href="/login/github">Continue with Github</Link>
+            </Button>
+            <Button asChild>
+              <Link href="/login/google">Continue with Google</Link>
+            </Button>
           </CardContent>
         </Card>
       </div>

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -10,9 +10,12 @@ export default function LoginPage() {
           <CardHeader>
             <h2 className="text-xl font-bold">Sign In</h2>
           </CardHeader>
-          <CardContent>
+          <CardContent className="grid gap-4">
             <Link href="/login/github">
               <Button>Continue with Github</Button>
+            </Link>
+            <Link href="/login/google">
+              <Button>Continue with Google</Button>
             </Link>
           </CardContent>
         </Card>

--- a/src/controllers/auth.ts
+++ b/src/controllers/auth.ts
@@ -1,0 +1,67 @@
+import { db } from "@/db";
+import { user, user_oauth } from "@/db/schema";
+import { Provider, lucia } from "@/lib/auth";
+import { generateId } from "lucia";
+import { cookies, headers } from "next/headers";
+
+interface UserAuth {
+  id: string;
+  name: string;
+  email: string;
+}
+
+export const save = async (data: UserAuth, provider: Provider) => {
+  const { id, name, email } = data;
+  const headerStore = headers();
+
+  const existingUser = await db.query.user_oauth.findFirst({
+    where: (field, op) =>
+      op.and(op.eq(field.provider, provider), op.eq(field.providerId, id)),
+  });
+
+  if (existingUser?.userId) {
+    const session = await lucia.createSession(existingUser.userId, {
+      auth_id: existingUser.id,
+      user_agent: headerStore.get("user-agent"),
+    });
+
+    const sessionCookie = lucia.createSessionCookie(session.id);
+
+    cookies().set(
+      sessionCookie.name,
+      sessionCookie.value,
+      sessionCookie.attributes
+    );
+
+    return new Response(null, {
+      status: 302,
+      headers: {
+        Location: "/connect",
+      },
+    });
+  }
+
+  const userId = generateId(15);
+  const authId = generateId(15);
+
+  await db.insert(user).values({ id: userId, name, email });
+  await db.insert(user_oauth).values({
+    id: authId,
+    provider: provider,
+    providerId: id,
+    userId: userId,
+  });
+
+  const session = await lucia.createSession(userId, {
+    auth_id: userId,
+    user_agent: headerStore.get("user-agent"),
+  });
+
+  const sessionCookie = lucia.createSessionCookie(session.id);
+
+  cookies().set(
+    sessionCookie.name,
+    sessionCookie.value,
+    sessionCookie.attributes
+  );
+};

--- a/src/env.ts
+++ b/src/env.ts
@@ -13,6 +13,9 @@ export const env = createEnv({
     GITHUB_CLIENT_ID: z.string().min(1),
     GITHUB_CLIENT_SECRET: z.string().min(1),
 
+    GOOGLE_CLIENT_ID: z.string().min(1),
+    GOOGLE_CLIENT_SECRET: z.string().min(1),
+
     ENCRYPTION_KEY: z.string().min(30),
   },
   experimental__runtimeEnv: {
@@ -21,5 +24,7 @@ export const env = createEnv({
     GITHUB_CLIENT_ID: process.env.GITHUB_CLIENT_ID,
     GITHUB_CLIENT_SECRET: process.env.GITHUB_CLIENT_SECRET,
     ENCRYPTION_KEY: process.env.ENCRYPTION_KEY,
+    GOOGLE_CLIENT_ID: process.env.GOOGLE_CLIENT_ID,
+    GOOGLE_CLIENT_SECRET: process.env.GOOGLE_CLIENT_SECRET,
   },
 });

--- a/src/env.ts
+++ b/src/env.ts
@@ -7,6 +7,7 @@ export const appVersion = pkg.version;
 
 export const env = createEnv({
   server: {
+    BASE_URL: z.string().min(1),
     DATABASE_URL: z.string().min(1),
     DATABASE_AUTH_TOKEN: z.string().min(1),
 

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -23,7 +23,7 @@ export const github = new GitHub(
 export const google = new Google(
   env.GOOGLE_CLIENT_ID,
   env.GOOGLE_CLIENT_SECRET,
-  "http://localhost:3000/login/google/callback"
+  `${env.BASE_URL}/login/google/callback`
 );
 
 const adapter = new LibSQLAdapter(connection, {

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,14 +1,29 @@
 import { Lucia } from "lucia";
-import { GitHub } from "arctic";
+import { GitHub, Google } from "arctic";
 import { LibSQLAdapter } from "@lucia-auth/adapter-sqlite";
 import { connection } from "@/db";
 import { env } from "@/env";
 import { cache } from "react";
 import { cookies, headers } from "next/headers";
 
+export const PROVIDER = {
+  GITHUB: "GITHUB",
+  GOOGLE: "GOOGLE",
+} as const;
+
+type ObjectValues<T> = T[keyof T];
+
+export type Provider = ObjectValues<typeof PROVIDER>;
+
 export const github = new GitHub(
   env.GITHUB_CLIENT_ID,
   env.GITHUB_CLIENT_SECRET
+);
+
+export const google = new Google(
+  env.GOOGLE_CLIENT_ID,
+  env.GOOGLE_CLIENT_SECRET,
+  "http://localhost:3000/login/google/callback"
 );
 
 const adapter = new LibSQLAdapter(connection, {


### PR DESCRIPTION
I introduced 3 new environment variables

`BASE_URL=http://localhost:3000` it's for google auth client redirect
`GOOGLE_CLIENT_ID=`
`GOOGLE_CLIENT_SECRET=`

I have also added AuthContoller [33-google-login/src/controllers/auth.ts](https://github.com/invisal/libsql-studio/blob/33-google-login/src/controllers/auth.ts) for easier to integrate with new provider.

To add login in with google, first need to create a new project at https://console.cloud.google.com/

Then create a consent screen at https://console.cloud.google.com/apis/credentials/consent with the scope below

<img width="583" alt="Screenshot 2024-03-20 at 4 33 56 in the afternoon" src="https://github.com/invisal/libsql-studio/assets/8617506/000515bf-82f4-4036-95a1-25c6b95885dd">

Then need to create 2 credentials OAuth client ID one for development and another one for production

for development need to config like below

<img width="576" alt="Screenshot 2024-03-20 at 4 33 22 in the afternoon" src="https://github.com/invisal/libsql-studio/assets/8617506/d953bb66-72e0-4c36-9271-9563f823d708">


