### PR TITLE
feat: better file type detection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,6 +55,7 @@
         "eslint-plugin-jest": "^27.6.3",
         "lucia": "^3.1.1",
         "lucide-react": "^0.309.0",
+        "magic-bytes.js": "^1.10.0",
         "next": "14.0.4",
         "oslo": "^1.1.3",
         "react": "^18",
@@ -12231,6 +12232,11 @@
       "bin": {
         "lz-string": "bin/bin.js"
       }
+    },
+    "node_modules/magic-bytes.js": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.10.0.tgz",
+      "integrity": "sha512-/k20Lg2q8LE5xiaaSkMXk4sfvI+9EGEykFS4b0CHHGWqDYU0bGUFSwchNOMA56D7TCs9GwVTkqe9als1/ns8UQ=="
     },
     "node_modules/make-dir": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "eslint-plugin-jest": "^27.6.3",
     "lucia": "^3.1.1",
     "lucide-react": "^0.309.0",
+    "magic-bytes.js": "^1.10.0",
     "next": "14.0.4",
     "oslo": "^1.1.3",
     "react": "^18",

--- a/src/lib/r2.ts
+++ b/src/lib/r2.ts
@@ -16,7 +16,7 @@ async function upload({
   filename,
   contentType,
 }: {
-  buffer: Buffer;
+  buffer: Buffer | Uint8Array;
   userId: string;
   filename: string;
   contentType: string;


### PR DESCRIPTION
### Description 

Add better file type detection for `/api/upload`. This is done using the `magic-bytes` package which has support for browser environment and a tons of file type support. 

- try to detect file type information using `magic-bytes`
- fallback to the `File` object `file.type` and `file.name`

We need to use a package that support browser api as we are running on edge.

---

### Caveat

Currently we store the filename in our `user_files` table. But in the case that let's say user upload a file of type `jpeg`.
But the file name is instead `filename.pdf`. In this case we correct the file type but we still store the filename as `filename.pdf`, do you have any suggestion for this?

<img width="1182" alt="image" src="https://github.com/invisal/libsql-studio/assets/106462074/29c59fba-6e5c-4896-a7c8-fba1cdff9f77">

---

### Demo (1.4x speed):

In the demo, I renamed a jpeg screenshot into `.pdf` but the api detected it as jpeg, and use that instead.

https://github.com/invisal/libsql-studio/assets/106462074/57cf68e8-a645-4e89-83ed-c22a7aeca72a

