### PR TITLE
fix(gui): stop safari from opening the native menu

### DIFF
--- a/gui/src/components/context-menu-handler.tsx
+++ b/gui/src/components/context-menu-handler.tsx
@@ -89,7 +89,7 @@ export default function ContextMenuHandler() {
     if (menu && contextRef.current) {
       const ev = new MouseEvent("contextmenu", {
         bubbles: true,
-        cancelable: false,
+        cancelable: true,
         view: window,
         button: 2,
         buttons: 2,


### PR DESCRIPTION
This PR change the `cancelable: false` to `cancelable: true` in the context menu `MouseEvent`. 

This allow the event to be prevented, e.g. `e.preventDefault()`
https://developer.mozilla.org/en-US/docs/Web/API/Event/cancelable

https://github.com/invisal/libsql-studio/assets/106462074/1806718d-6559-4962-ba57-e77d2cbcdc06

closes #85 

