### PR TITLE
feat: add export rows as json

### DIFF
--- a/src/components/gui/query-result-table.tsx
+++ b/src/components/gui/query-result-table.tsx
@@ -9,6 +9,7 @@ import OptimizeTableState from "@/components/gui/table-optimized/OptimizeTableSt
 import {
   exportRowsToExcel,
   exportRowsToSqlInsert,
+  exportRowsToJson,
 } from "@/components/lib/export-helper";
 import { KEY_BINDING } from "@/lib/key-matcher";
 import {
@@ -430,6 +431,20 @@ export default function ResultTable({
                 if (state.getSelectedRowCount() > 0) {
                   window.navigator.clipboard.writeText(
                     exportRowsToExcel(state.getSelectedRowsArray())
+                  );
+                }
+              },
+            },
+            {
+              title: "Copy as Json",
+              onClick: () => {
+                const headers = state
+                  .getHeaders()
+                  .map((column) => column?.name ?? "");
+
+                if (state.getSelectedRowCount() > 0) {
+                  window.navigator.clipboard.writeText(
+                    exportRowsToJson(headers, state.getSelectedRowsArray())
                   );
                 }
               },


### PR DESCRIPTION
I wanted to copy a row as javascript object, but the button wasn't there


https://github.com/user-attachments/assets/625aafaf-ff24-4ac6-8392-9782baca745b

