### PR TITLE
fix: button "close" click event targeting the icon instead of the entire container

### DIFF
--- a/src/components/gui/sortable-tab.tsx
+++ b/src/components/gui/sortable-tab.tsx
@@ -47,13 +47,13 @@ export const WindowTabItemButton = forwardRef<
             "rounded-full hover:bg-red-600 hover:text-white w-4 h-4 ml-2 flex justify-center items-center",
             "libsql-window-close"
           )}
+          onClick={(e) => {
+            e.stopPropagation();
+            if (onClose) onClose();
+          }}
         >
           <LucideX
             className={cn("w-3 h-3 grow-0 shrink-0", "libsql-window-close")}
-            onClick={(e) => {
-              e.stopPropagation();
-              if (onClose) onClose();
-            }}
           />
         </div>
       )}


### PR DESCRIPTION
This issue caused the tab to close only when clicking specifically on the icon, even though the hover effect suggested that the entire container was clickable.

![image](https://github.com/user-attachments/assets/2d776021-fa50-4737-b00c-dcc13bdc25c7)

The **green box** (the _icon_ itself) is in fact the event element that supports _click_, while this should be the responsibility of the container marked in **blue**.