### PR TITLE
fix: handle values according to their received type, not the column-defined type (fixes #137)

### DIFF
--- a/src/components/gui/query-result-table.tsx
+++ b/src/components/gui/query-result-table.tsx
@@ -24,7 +24,6 @@ import {
   DropdownMenuSeparator,
 } from "../ui/dropdown-menu";
 import useTableResultContextMenu from "./table-result/context-menu";
-import useTableResultCellRenderer from "./table-result/render-cell";
 
 interface ResultTableProps {
   data: OptimizeTableState;
@@ -176,7 +175,6 @@ export default function ResultTable({
     }
   }, []);
 
-  const onRenderCell = useTableResultCellRenderer();
   const onCellContextMenu = useTableResultContextMenu({
     tableName,
     data,
@@ -247,7 +245,6 @@ export default function ResultTable({
       arrangeHeaderIndex={headerIndex}
       renderAhead={20}
       renderHeader={renderHeader}
-      renderCell={onRenderCell}
       rowHeight={35}
       onKeyDown={onKeyDown}
     />

--- a/src/components/gui/table-optimized/index.tsx
+++ b/src/components/gui/table-optimized/index.tsx
@@ -19,6 +19,7 @@ import {
   TableColumnDataType,
 } from "@/drivers/base-driver";
 import { cn } from "@/lib/utils";
+import tableResultCellRenderer from "@/components/gui/table-result/render-cell";
 
 export interface OptimizeTableHeaderProps {
   name: string;
@@ -54,7 +55,6 @@ interface TableCellListCommonProps {
     props: OptimizeTableHeaderWithIndexProps,
     idx: number
   ) => ReactElement;
-  renderCell: (props: OptimizeTableCellRenderProps) => ReactElement;
   rowHeight: number;
   onHeaderContextMenu?: (
     e: React.MouseEvent,
@@ -123,7 +123,6 @@ function renderCellList({
   hasSticky,
   customStyles,
   headers,
-  renderCell,
   rowEnd,
   rowStart,
   colEnd,
@@ -191,7 +190,7 @@ function renderCellList({
           >
             <div className={"libsql-table-cell"}>
               {headers[0] &&
-                renderCell({
+                tableResultCellRenderer({
                   y: absoluteRowIndex,
                   x: headers[0].index,
                   state: internalState,
@@ -219,7 +218,7 @@ function renderCellList({
               onMouseDown={handleCellClicked(absoluteRowIndex, header.index)}
             >
               <div className={"libsql-table-cell"}>
-                {renderCell({
+                {tableResultCellRenderer({
                   y: absoluteRowIndex,
                   x: header.index,
                   state: internalState,
@@ -260,7 +259,6 @@ function renderCellList({
 export default function OptimizeTable({
   stickyHeaderIndex,
   internalState,
-  renderCell,
   renderHeader,
   rowHeight,
   renderAhead,
@@ -325,7 +323,6 @@ export default function OptimizeTable({
   return useMemo(() => {
     const common = {
       headers: headerWithIndex,
-      renderCell,
       rowEnd,
       rowStart,
       colEnd,
@@ -370,7 +367,6 @@ export default function OptimizeTable({
     rowStart,
     colEnd,
     colStart,
-    renderCell,
     rowHeight,
     headerWithIndex,
     onHeaderResize,

--- a/src/components/gui/table-result/render-cell.tsx
+++ b/src/components/gui/table-result/render-cell.tsx
@@ -30,6 +30,7 @@ function detectTextEditorType(
 }
 
 function determineCellType(value: unknown) {
+  if (value === null) return undefined;
   if (typeof value === "bigint") return TableColumnDataType.INTEGER;
   if (typeof value === "number") return TableColumnDataType.REAL;
   if (typeof value === "string") return TableColumnDataType.TEXT;

--- a/src/components/gui/table-result/render-cell.tsx
+++ b/src/components/gui/table-result/render-cell.tsx
@@ -1,4 +1,3 @@
-import { useCallback } from "react";
 import { OptimizeTableCellRenderProps } from "../table-optimized";
 import { DatabaseValue, TableColumnDataType } from "@/drivers/base-driver";
 import TextCell from "../table-cell/text-cell";
@@ -6,7 +5,6 @@ import parseSafeJson from "@/lib/json-safe";
 import NumberCell from "../table-cell/number-cell";
 import BigNumberCell from "../table-cell/big-number-cell";
 import GenericCell from "../table-cell/generic-cell";
-import { useDatabaseDriver } from "@/context/driver-provider";
 
 function detectTextEditorType(
   value: DatabaseValue<string>
@@ -31,85 +29,73 @@ function detectTextEditorType(
   return "input";
 }
 
-export default function useTableResultCellRenderer() {
-  const { databaseDriver } = useDatabaseDriver();
+function determineCellType(value: unknown) {
+  if (typeof value === "bigint") return TableColumnDataType.INTEGER;
+  if (typeof value === "number") return TableColumnDataType.REAL;
+  if (typeof value === "string") return TableColumnDataType.TEXT;
+  if (typeof value === "object") return TableColumnDataType.BLOB;
 
-  return useCallback(
-    ({ y, x, state, header }: OptimizeTableCellRenderProps) => {
-      const isFocus = state.hasFocus(y, x);
-      const editMode = isFocus && state.isInEditMode();
+  return undefined;
+}
 
-      if (header.dataType === TableColumnDataType.TEXT) {
-        const value = state.getValue(y, x) as DatabaseValue<string>;
-        const editor = detectTextEditorType(value);
+export default function tableResultCellRenderer({
+  y,
+  x,
+  state,
+  header,
+}: OptimizeTableCellRenderProps) {
+  const isFocus = state.hasFocus(y, x);
+  const editMode = isFocus && state.isInEditMode();
+  const value = state.getValue(y, x);
 
-        return (
-          <TextCell
-            header={header}
-            state={state}
-            editor={editor}
-            editMode={editMode}
-            value={state.getValue(y, x) as DatabaseValue<string>}
-            focus={isFocus}
-            isChanged={state.hasCellChange(y, x)}
-            onChange={(newValue) => {
-              state.changeValue(y, x, newValue);
-            }}
-          />
-        );
-      } else if (header.dataType === TableColumnDataType.REAL) {
-        return (
-          <NumberCell
-            header={header}
-            state={state}
-            editMode={editMode}
-            value={state.getValue(y, x) as DatabaseValue<number>}
-            focus={isFocus}
-            isChanged={state.hasCellChange(y, x)}
-            onChange={(newValue) => {
-              state.changeValue(y, x, newValue);
-            }}
-          />
-        );
-      } else if (header.dataType === TableColumnDataType.INTEGER) {
-        if (
-          databaseDriver.supportBigInt() &&
-          Number.isInteger(state.getValue(y, x))
-        ) {
-          return (
-            <BigNumberCell
-              header={header}
-              state={state}
-              editMode={editMode}
-              value={state.getValue(y, x) as DatabaseValue<bigint>}
-              focus={isFocus}
-              isChanged={state.hasCellChange(y, x)}
-              onChange={(newValue) => {
-                state.changeValue(y, x, newValue);
-              }}
-            />
-          );
-        } else {
-          return (
-            <NumberCell
-              header={header}
-              state={state}
-              editMode={editMode}
-              value={state.getValue(y, x) as DatabaseValue<number>}
-              focus={isFocus}
-              isChanged={state.hasCellChange(y, x)}
-              onChange={(newValue) => {
-                state.changeValue(y, x, newValue);
-              }}
-            />
-          );
-        }
-      }
-
+  switch (determineCellType(value) ?? header.dataType) {
+    case TableColumnDataType.INTEGER:
       return (
-        <GenericCell value={state.getValue(y, x) as string} header={header} />
+        <BigNumberCell
+          header={header}
+          state={state}
+          editMode={editMode}
+          value={value as DatabaseValue<bigint>}
+          focus={isFocus}
+          isChanged={state.hasCellChange(y, x)}
+          onChange={(newValue) => {
+            state.changeValue(y, x, newValue);
+          }}
+        />
       );
-    },
-    [databaseDriver]
-  );
+
+    case TableColumnDataType.REAL:
+      return (
+        <NumberCell
+          header={header}
+          state={state}
+          editMode={editMode}
+          value={value as DatabaseValue<number>}
+          focus={isFocus}
+          isChanged={state.hasCellChange(y, x)}
+          onChange={(newValue) => {
+            state.changeValue(y, x, newValue);
+          }}
+        />
+      );
+
+    case TableColumnDataType.TEXT:
+      return (
+        <TextCell
+          header={header}
+          state={state}
+          editor={detectTextEditorType(value as DatabaseValue<string>)}
+          editMode={editMode}
+          value={value as DatabaseValue<string>}
+          focus={isFocus}
+          isChanged={state.hasCellChange(y, x)}
+          onChange={(newValue) => {
+            state.changeValue(y, x, newValue);
+          }}
+        />
+      );
+
+    default:
+      return <GenericCell value={value as string} header={header} />;
+  }
 }


### PR DESCRIPTION
Since SQLite is flexible with types, we can't blindly trust the column-defined type. Instead, we now determine the display type based on the type of the received data.

**Here's how it works:**

- A `string` received type will be treated as `TEXT`.
- A `bigint` received type will be treated as `INTEGER` (since the `BigNumberCell` component handles `bigint`, which aligns with how `INTEGER` data is managed internally).
- A `number` received type will be treated as `REAL` (because the `NumberCell` component can handle `number`, which can represent both `integer` or `float` in JavaScript, so even if an `INTEGER` is treated as `number`, it won't be an issue).
- An `object` (Array) received type will be treated as `BLOB`.
- `BLOB` or `NULL` types are handled as generic types (managed by the `GenericCell` component).
- When there is no received type (e.g., when inserting a new value), we default to using the column type as before.

**Additional improvements:**

- `useTableResultCellRenderer()` has been refactored into a direct callback instead of a React hook since it no longer has hook dependencies (specifically, `useDatabaseDriver()`). As there was only one use of this hook, I moved the call directly to the final point of use instead of passing it down through component dependencies.

**Additional notes:**

- It would be important to test with other data sources. I only tested with SQLite and Turso.