### PR TITLE
refactor: use green color for texts (optional, suggestion)

### DIFF
--- a/src/components/gui/table-cell/generic-cell.tsx
+++ b/src/components/gui/table-cell/generic-cell.tsx
@@ -212,7 +212,7 @@ export default function GenericCell({
       return (
         <span
           className={
-            isChanged ? "text-black" : "text-gray-500 dark:text-gray-300"
+            isChanged ? "text-black" : "text-green-600 dark:text-green-500"
           }
         >
           {value}


### PR DESCRIPTION
This is a pattern used by HeidiSQL: text is green to differentiate it from similar non-text, such as NULL.

![image](https://github.com/user-attachments/assets/a192fc1b-7e18-4393-a099-4992be3bf9f0)

![image](https://github.com/user-attachments/assets/2a6e6f62-15be-4dd3-a275-66c8163e235f)
![image](https://github.com/user-attachments/assets/041b5d62-33f0-424c-a1e2-ff82d1f8157b)
