### PR TITLE
feat: added a type mismatch indicator (fixes #138)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -228,6 +228,14 @@ body {
   color: var(--color-text);
 }
 
+.libsql-mismatch-arrow {
+  width: 0;
+  height: 0;
+  border-style: solid;
+  border-width: 0 8px 8px 0;
+  border-color: transparent theme("colors.red.400") transparent transparent;
+}
+
 .dark .libsql-removed-row td {
   @apply bg-red-800;
 }

--- a/src/components/gui/table-cell/create-editable-cell.tsx
+++ b/src/components/gui/table-cell/create-editable-cell.tsx
@@ -1,12 +1,13 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import GenericCell from "./generic-cell";
-import { DatabaseValue } from "@/drivers/base-driver";
+import { DatabaseValue, TableColumnDataType } from "@/drivers/base-driver";
 import OptimizeTableState from "../table-optimized/OptimizeTableState";
 import { useFullEditor } from "../providers/full-editor-provider";
 import { OptimizeTableHeaderWithIndexProps } from "../table-optimized";
 
 export interface TableEditableCell<T = unknown> {
   value: DatabaseValue<T>;
+  valueType: TableColumnDataType | undefined;
   isChanged?: boolean;
   focus?: boolean;
   editMode?: boolean;
@@ -104,6 +105,7 @@ export default function createEditableCell<T = unknown>({
 }: TabeEditableCellProps<T>): React.FC<TableEditableCell<T>> {
   return function GenericEditableCell({
     value,
+    valueType,
     isChanged,
     focus,
     onChange,
@@ -164,6 +166,7 @@ export default function createEditableCell<T = unknown>({
       <GenericCell
         header={header}
         value={toValue(editValue)}
+        valueType={valueType}
         focus={focus}
         isChanged={isChanged}
         align={align}

--- a/src/components/gui/table-cell/generic-cell.tsx
+++ b/src/components/gui/table-cell/generic-cell.tsx
@@ -9,13 +9,24 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
-import { DatabaseResultSet, DatabaseValue } from "@/drivers/base-driver";
+import {
+  DatabaseResultSet,
+  DatabaseValue,
+  describeTableColumnType,
+  TableColumnDataType,
+} from "@/drivers/base-driver";
 import { useDatabaseDriver } from "@/context/driver-provider";
 import { convertDatabaseValueToString } from "@/drivers/sqlite/sql-helper";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 interface TableCellProps<T = unknown> {
   align?: "left" | "right";
   value: T;
+  valueType?: TableColumnDataType;
   focus?: boolean;
   isChanged?: boolean;
   onFocus?: () => void;
@@ -157,6 +168,7 @@ function BlobCellValue({
 
 export default function GenericCell({
   value,
+  valueType,
   onFocus,
   isChanged,
   focus,
@@ -254,13 +266,36 @@ export default function GenericCell({
   }, [value, textBaseStyle, isChanged, header]);
 
   return (
-    <div
-      className={className}
-      onMouseDown={onFocus}
-      onDoubleClick={onDoubleClick}
-    >
-      <div className="flex flex-grow overflow-hidden">{content}</div>
-      {fkContent}
+    <div className="relative">
+      {valueType && header.dataType && valueType !== header.dataType && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <div className="libsql-mismatch-arrow absolute right-0 top-0"></div>
+          </TooltipTrigger>
+          <TooltipContent>
+            <strong>Mismatched type:</strong>
+            <ul>
+              <li>
+                <strong>- Expected by column:</strong>{" "}
+                <code>{describeTableColumnType(header.dataType)}</code>
+              </li>
+              <li>
+                <strong>- But stored as:</strong>{" "}
+                <code>{describeTableColumnType(valueType)}</code>
+              </li>
+            </ul>
+          </TooltipContent>
+        </Tooltip>
+      )}
+
+      <div
+        className={className}
+        onMouseDown={onFocus}
+        onDoubleClick={onDoubleClick}
+      >
+        <div className="flex flex-grow overflow-hidden">{content}</div>
+        {fkContent}
+      </div>
     </div>
   );
 }

--- a/src/components/gui/table-result/render-cell.tsx
+++ b/src/components/gui/table-result/render-cell.tsx
@@ -48,8 +48,9 @@ export default function tableResultCellRenderer({
   const isFocus = state.hasFocus(y, x);
   const editMode = isFocus && state.isInEditMode();
   const value = state.getValue(y, x);
+  const valueType = determineCellType(value);
 
-  switch (determineCellType(value) ?? header.dataType) {
+  switch (valueType ?? header.dataType) {
     case TableColumnDataType.INTEGER:
       return (
         <BigNumberCell
@@ -57,6 +58,7 @@ export default function tableResultCellRenderer({
           state={state}
           editMode={editMode}
           value={value as DatabaseValue<bigint>}
+          valueType={valueType}
           focus={isFocus}
           isChanged={state.hasCellChange(y, x)}
           onChange={(newValue) => {
@@ -72,6 +74,7 @@ export default function tableResultCellRenderer({
           state={state}
           editMode={editMode}
           value={value as DatabaseValue<number>}
+          valueType={valueType}
           focus={isFocus}
           isChanged={state.hasCellChange(y, x)}
           onChange={(newValue) => {
@@ -88,6 +91,7 @@ export default function tableResultCellRenderer({
           editor={detectTextEditorType(value as DatabaseValue<string>)}
           editMode={editMode}
           value={value as DatabaseValue<string>}
+          valueType={valueType}
           focus={isFocus}
           isChanged={state.hasCellChange(y, x)}
           onChange={(newValue) => {

--- a/src/drivers/base-driver.ts
+++ b/src/drivers/base-driver.ts
@@ -15,6 +15,22 @@ export enum TableColumnDataType {
   BLOB = 4,
 }
 
+export function describeTableColumnType(type: TableColumnDataType) {
+  switch (type) {
+    case TableColumnDataType.TEXT:
+      return "TEXT";
+
+    case TableColumnDataType.INTEGER:
+      return "INTEGER";
+
+    case TableColumnDataType.REAL:
+      return "REAL";
+
+    case TableColumnDataType.BLOB:
+      return "BLOB";
+  }
+}
+
 export type SqlOrder = "ASC" | "DESC";
 export type DatabaseRow = Record<string, unknown>;
 
@@ -22,7 +38,7 @@ export interface DatabaseHeader {
   name: string;
   displayName: string;
   originalType: string | null;
-  type: TableColumnDataType;
+  type: TableColumnDataType | undefined;
 }
 
 export interface DatabaseResultStat {

--- a/src/drivers/sqlite/sql-helper.ts
+++ b/src/drivers/sqlite/sql-helper.ts
@@ -34,8 +34,9 @@ export function escapeSqlValue(value: unknown) {
 
 export function convertSqliteType(
   type: string | undefined
-): TableColumnDataType {
+): TableColumnDataType | undefined {
   // https://www.sqlite.org/datatype3.html
+  if (type === "") return undefined;
   if (type === undefined) return TableColumnDataType.BLOB;
 
   type = type.toUpperCase();


### PR DESCRIPTION
When a column is defined with one type (e.g., `INTEGER`) but stores a value of another type (e.g., `TEXT`), an indicator is displayed with a tooltip showing the mismatched type. This is very useful since SQLite has flexible typing, which can cause issues when the data is handled in an environment where this behavior is not expected.

![image](https://github.com/user-attachments/assets/bf5e27f7-9b13-47c5-aabc-2d9fb03e70a5)
![image](https://github.com/user-attachments/assets/e1f06e4e-9a0e-4cb8-80b3-2a51975babb5)
![image](https://github.com/user-attachments/assets/d2b34e67-290c-4d9f-ad83-d19ee4e82ddc)


**Important information:**

I had to modify a series of files to make this work properly, but I tried to do it in the best way possible. However, the `convertSqliteType()` function in the `sql-helper.ts` file made me the most "uncomfortable," since it's used in many places.

I had to make this change because there are cases where the type is not explicitly defined for SQLite, such as when accessing the default `sqlite_sequence` table. It defines `name` and `seq`, but their types are `""` (literally _empty_), and currently, the code was forcing them to be interpreted as `TEXT`, which seems incorrect. For example, `seq` is sent as an _integer_, so it should be treated as `INTEGER`.

This was done to ensure that the mismatch comparison system stops considering this field for analysis, as the column type is natively _undefined_.
