### PR TITLE
fix: prevent visual glitch when entering field edit mode

### DIFF
--- a/src/components/gui/table-cell/create-editable-cell.tsx
+++ b/src/components/gui/table-cell/create-editable-cell.tsx
@@ -4,6 +4,7 @@ import { DatabaseValue } from "@/drivers/base-driver";
 import OptimizeTableState from "../table-optimized/OptimizeTableState";
 import { useFullEditor } from "../providers/full-editor-provider";
 import { OptimizeTableHeaderWithIndexProps } from "../table-optimized";
+import { cn } from "@/lib/utils";
 
 export interface TableEditableCell<T = unknown> {
   value: DatabaseValue<T>;
@@ -136,17 +137,15 @@ export default function createEditableCell<T = unknown>({
       state.exitEditMode();
     }, [setEditValue, state, value]);
 
-    const className = [
-      "libsql-cell",
-      focus ? "libsql-focus" : null,
-      isChanged ? "libsql-change" : null,
-    ]
-      .filter(Boolean)
-      .join(" ");
-
     if (editMode && (editor === undefined || editor === "input")) {
       return (
-        <div className={className}>
+        <div
+          className={cn(
+            "libsql-cell flex",
+            focus && "libsql-focus",
+            isChanged && "libsql-change"
+          )}
+        >
           <InputCellEditor
             state={state}
             readOnly={state.getReadOnlyMode()}


### PR DESCRIPTION
Currently, when a field enters edit mode, its height exceeds the outermost container's height. Applying the `flex` class forces it to respect the height limit, preventing the bottom border from disappearing.

**Before:**

![image](https://github.com/user-attachments/assets/03f90e3c-a4dc-4dc2-8749-183df03634d2)

**After:**

![image](https://github.com/user-attachments/assets/3882950a-4d05-41d7-a7a1-6192542c82f4)
