### PR TITLE
refactor: try to display binary data (BLOB) whenever possible

### DIFF
--- a/src/components/gui/table-cell/blob-cell.tsx
+++ b/src/components/gui/table-cell/blob-cell.tsx
@@ -1,0 +1,27 @@
+import { prettifyBytes } from "@/components/gui/table-cell/generic-cell";
+import createEditableCell from "./create-editable-cell";
+
+const BlobCell = createEditableCell<number[]>({
+  toString: (v) => {
+    if (v === null) return null;
+    if (v === undefined) return undefined;
+
+    return prettifyBytes(Uint8Array.from(v ?? []));
+  },
+  toValue: (v) => {
+    if (v === null) return null;
+    if (v === undefined) return undefined;
+    if (v === "") return null;
+
+    return [...v.matchAll(/(\\\\)|\\x([0-9a-f]{2})|(.)/gi)].map(
+      ([, escape, hex, letter]) =>
+        escape !== undefined
+          ? 0x5c
+          : letter !== undefined
+            ? letter.codePointAt(0)
+            : parseInt(hex, 16)
+    ) as number[];
+  },
+});
+
+export default BlobCell;

--- a/src/components/gui/table-cell/generic-cell.tsx
+++ b/src/components/gui/table-cell/generic-cell.tsx
@@ -110,6 +110,16 @@ function ForeignKeyColumnSnippet(props: SneakpeakProps) {
   );
 }
 
+function prettifyBytes(bytes: Uint8Array) {
+  return [...bytes.subarray(0, 64)]
+    .map((b) =>
+      b >= 0x20 && b !== 0x7f
+        ? String.fromCharCode(b)
+        : "\\x" + b.toString(16).toUpperCase().padStart(2, "0")
+    )
+    .join("");
+}
+
 function BlobCellValue({
   value,
   vector,
@@ -133,23 +143,20 @@ function BlobCellValue({
     );
   } else {
     const bytes = new Uint8Array(value);
-    const base64Text = btoa(
-      bytes
-        .slice(0, 64)
-        .reduce((data, byte) => data + String.fromCharCode(byte), "")
-    );
 
     return (
-      <div className="flex">
-        <div className="mr-2 justify-center items-center flex-col">
+      <div className="flex w-full">
+        <span className="flex-1 text-ellipsis overflow-hidden whitespace-nowrap text-orange-600 dark:text-orange-400">
+          {prettifyBytes(bytes)}
+        </span>
+        <div className="ml-2 justify-center items-center flex-col">
           <span className="bg-blue-500 text-white inline rounded p-1 pl-2 pr-2">
             {bytes.length.toLocaleString(undefined, {
               maximumFractionDigits: 0,
-            })}{" "}
-            bytes
+            })}
+            {" bytes"}
           </span>
         </div>
-        <div className="text-orange-600">{base64Text}</div>
       </div>
     );
   }

--- a/src/components/gui/table-cell/generic-cell.tsx
+++ b/src/components/gui/table-cell/generic-cell.tsx
@@ -110,12 +110,14 @@ function ForeignKeyColumnSnippet(props: SneakpeakProps) {
   );
 }
 
-function prettifyBytes(bytes: Uint8Array) {
-  return [...bytes.subarray(0, 64)]
+export function prettifyBytes(bytes: Uint8Array) {
+  return [...bytes]
     .map((b) =>
-      b >= 0x20 && b !== 0x7f
-        ? String.fromCharCode(b)
-        : "\\x" + b.toString(16).toUpperCase().padStart(2, "0")
+      b === 0x5c
+        ? "\\\\"
+        : b >= 0x20 && b !== 0x7f
+          ? String.fromCharCode(b)
+          : "\\x" + b.toString(16).toUpperCase().padStart(2, "0")
     )
     .join("");
 }
@@ -147,7 +149,7 @@ function BlobCellValue({
     return (
       <div className="flex w-full">
         <span className="flex-1 text-ellipsis overflow-hidden whitespace-nowrap text-orange-600 dark:text-orange-400">
-          {prettifyBytes(bytes)}
+          {prettifyBytes(bytes.subarray(0, 64))}
         </span>
         <div className="ml-2 justify-center items-center flex-col">
           <span className="bg-blue-500 text-white inline rounded p-1 pl-2 pr-2">

--- a/src/components/gui/table-optimized/OptimizeTableState.tsx
+++ b/src/components/gui/table-optimized/OptimizeTableState.tsx
@@ -7,6 +7,7 @@ import {
   TableColumnDataType,
 } from "@/drivers/base-driver";
 import { ReactElement } from "react";
+import deepEqual from "deep-equal";
 
 export interface OptimizeTableRowValue {
   raw: Record<string, unknown>;
@@ -202,7 +203,7 @@ export default class OptimizeTableState {
 
     if (!row) return;
 
-    if (oldValue === newValue) {
+    if (deepEqual(oldValue, newValue)) {
       const rowChange = row.change;
       if (rowChange && headerName in rowChange) {
         delete rowChange[headerName];

--- a/src/components/gui/table-result/render-cell.tsx
+++ b/src/components/gui/table-result/render-cell.tsx
@@ -5,6 +5,7 @@ import parseSafeJson from "@/lib/json-safe";
 import NumberCell from "../table-cell/number-cell";
 import BigNumberCell from "../table-cell/big-number-cell";
 import GenericCell from "../table-cell/generic-cell";
+import BlobCell from "@/components/gui/table-cell/blob-cell";
 
 function detectTextEditorType(
   value: DatabaseValue<string>
@@ -88,6 +89,21 @@ export default function tableResultCellRenderer({
           editor={detectTextEditorType(value as DatabaseValue<string>)}
           editMode={editMode}
           value={value as DatabaseValue<string>}
+          focus={isFocus}
+          isChanged={state.hasCellChange(y, x)}
+          onChange={(newValue) => {
+            state.changeValue(y, x, newValue);
+          }}
+        />
+      );
+
+    case TableColumnDataType.BLOB:
+      return (
+        <BlobCell
+          header={header}
+          state={state}
+          editMode={editMode}
+          value={value as DatabaseValue<number[]>}
           focus={isFocus}
           isChanged={state.hasCellChange(y, x)}
           onChange={(newValue) => {

--- a/src/drivers/sqlite/sql-helper.ts
+++ b/src/drivers/sqlite/sql-helper.ts
@@ -28,6 +28,8 @@ export function escapeSqlValue(value: unknown) {
   if (typeof value === "number") return value.toString();
   if (typeof value === "bigint") return value.toString();
   if (value instanceof ArrayBuffer) return escapeSqlBinary(value);
+  if (Array.isArray(value))
+    return escapeSqlBinary(Uint8Array.from(value).buffer);
   // eslint-disable-next-line @typescript-eslint/no-base-to-string
   throw new Error(value.toString() + " is unrecongize type of value");
 }


### PR DESCRIPTION
Characters that cannot be displayed legibly are transformed into `\x{XX}`.

I believe this change is valuable because sometimes I use BLOBs to store data that may or may not be encoded, depending on the context. And when they are not encoded, I would like to be able to read them. Additionally, it's better to be able to read as hex rather than base64.

**Before:**

![image](https://github.com/user-attachments/assets/cd26ae98-eb02-4d13-8112-b0e3872bff8a)

**After:**

![image](https://github.com/user-attachments/assets/bb554fb6-267a-4559-ab04-c892f9b10a8c)

![image](https://github.com/user-attachments/assets/2bba0e9f-20d9-4f54-9474-8a99c806efe3)

**Important:** the second commit provides the ability to **create and edit BLOB fields**, while the first commit only changes how they are displayed. The first commit is essential for making BLOBs more readable and easier to modify. However, you can accept the first commit without necessarily accepting the second.




