### PR TITLE
fix: Call to `/status` to ensure it is valid rqlite node

### DIFF
--- a/src/components/connection-config-editor/template/rqlite.tsx
+++ b/src/components/connection-config-editor/template/rqlite.tsx
@@ -11,6 +11,21 @@ const template: CommonConnectionConfigTemplate = [
         required: true,
         placeholder: "Hostname or IP address",
       },
+      {
+        name: "port",
+        label: "Port",
+        type: "number",
+        required: true,
+        placeholder: "4001",
+        defaultValue: 4001,
+      },
+      {
+        name: "useSSL",
+        label: "Use SSL",
+        type: "boolean",
+        required: false,
+        defaultValue: false,
+      },
     ],
   },
   {
@@ -48,21 +63,4 @@ const instruction = (
 export const RqliteConnectionTemplate: ConnectionTemplateList = {
   template,
   instruction,
-  localFrom: (value) => {
-    return {
-      name: value.name,
-      host: value.url,
-      username: value.username,
-      password: value.password,
-    };
-  },
-  localTo: (value) => {
-    return {
-      name: value.name,
-      driver: "rqlite",
-      url: value.host,
-      username: value.username,
-      password: value.password,
-    };
-  },
 };

--- a/src/drivers/database/rqlite.ts
+++ b/src/drivers/database/rqlite.ts
@@ -5,6 +5,7 @@ import {
   QueryableBaseDriver,
 } from "@/drivers/base-driver";
 import { convertSqliteType } from "../sqlite/sql-helper";
+import { HttpStatus } from "@/constants/http-status";
 
 interface RqliteResult {
   columns?: string[];
@@ -18,6 +19,15 @@ interface RqliteResult {
 
 interface RqliteResultSet {
   results: RqliteResult[];
+}
+
+interface RqliteStatusResponse {
+  node?: {
+    start_time?: string;
+  };
+  cluster?: {
+    addr?: string;
+  };
 }
 
 export function transformRawResult(raw: RqliteResult): DatabaseResultSet {
@@ -54,59 +64,107 @@ export function transformRawResult(raw: RqliteResult): DatabaseResultSet {
     : [];
 
   return {
-    rows,
-    stat: {
-      rowsAffected: raw?.rows_affected ?? 0,
-      rowsRead: null,
-      rowsWritten: null,
-      queryDurationMs: raw?.time ?? 0,
-    },
     headers,
-    lastInsertRowid:
-      raw.last_insert_id === undefined ? undefined : raw.last_insert_id,
+    rows,
+    lastInsertRowId: raw.last_insert_id,
+    rowsAffected: raw.rows_affected,
+    executionTimeMs: raw.time,
+    error: raw.error,
   };
 }
 
-export class RqliteQueryable implements QueryableBaseDriver {
+export class RqliteDriver extends QueryableBaseDriver {
+  private baseUrl: string;
+
   constructor(
-    protected endpoint: string,
-    protected username?: string,
-    protected password?: string
-  ) {}
-
-  async transaction(stmts: string[]): Promise<DatabaseResultSet[]> {
-    let headers: HeadersInit = {
-      "Content-Type": "application/json",
-    };
-
-    if (this.username) {
-      headers = {
-        ...headers,
-        Authorization: "Basic " + btoa(this.username + ":" + this.password),
-      };
-    }
-
-    // https://rqlite.io/docs/api/api/#unified-endpoint
-    const result = await fetch(this.endpoint + "/db/request?timings", {
-      method: "POST",
-      headers,
-      body: JSON.stringify(
-        stmts.map((s) => {
-          return [s];
-        })
-      ),
-    });
-
-    const json: RqliteResultSet = await result.json();
-
-    for (const r of json.results) {
-      if (r.error) throw new Error(r.error);
-    }
-
-    return json.results.map(transformRawResult);
+    private host: string,
+    private port: number,
+    private username: string,
+    private password: string,
+    private useSSL: boolean = false
+  ) {
+    super();
+    const protocol = useSSL ? "https" : "http";
+    this.baseUrl = `${protocol}://${this.host}:${this.port}`;
   }
 
-  async query(stmt: string): Promise<DatabaseResultSet> {
-    return (await this.transaction([stmt]))[0];
+  async testConnection(): Promise<boolean> {
+    const rootUrl = `${this.baseUrl}/`;
+    const statusUrl = `${this.baseUrl}/status`;
+
+    try {
+      const rootResponse = await fetch(rootUrl, { method: "GET", redirect: "manual" });
+      if (rootResponse.status !== HttpStatus.FOUND) {
+        return false;
+      }
+
+      const versionHeader = rootResponse.headers.get("X-Rqlite-Version");
+      if (!versionHeader) {
+        return false;
+      }
+
+      const location = rootResponse.headers.get("Location");
+      if (!location || location !== "/status") {
+        return false;
+      }
+
+      const statusResponse = await fetch(statusUrl, {
+        method: "GET",
+        headers: {
+          Authorization: `Basic ${btoa(`${this.username}:${this.password}`)}`,
+        },
+      });
+
+      if (!statusResponse.ok) {
+        return false;
+      }
+
+      const statusData: RqliteStatusResponse = await statusResponse.json();
+      if (!statusData.node || !statusData.cluster) {
+        return false;
+      }
+
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async query(sql: string): Promise<DatabaseResultSet[]> {
+    const url = `${this.baseUrl}/db/query`;
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Basic ${btoa(`${this.username}:${this.password}`)}`,
+      },
+      body: JSON.stringify({ statements: sql }),
+    });
+
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+    }
+
+    const result: RqliteResultSet = await response.json();
+    return result.results.map(transformRawResult);
+  }
+
+  async execute(sql: string): Promise<DatabaseResultSet[]> {
+    const url = `${this.baseUrl}/db/execute`;
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Basic ${btoa(`${this.username}:${this.password}`)}`,
+      },
+      body: JSON.stringify({ statements: sql }),
+    });
+
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+    }
+
+    const result: RqliteResultSet = await response.json();
+    return result.results.map(transformRawResult);
   }
 }


### PR DESCRIPTION
Adds explicit network test connect call to `/status` endpoint for rqlite node validation

This PR introduces a check to ensure a valid rqlite node connection by calling the `/status` endpoint and verifying a 200 response status code. The implementation aligns with the rqlite project's main.go file, which sets the `X-Rqlite-Version` HTTP header.

Closes #<number>

Closes #59